### PR TITLE
Bugfix: Use float weight matrix instead of uint8

### DIFF
--- a/modules/networkAnalysis.py
+++ b/modules/networkAnalysis.py
@@ -59,7 +59,7 @@ def create_adjacency_matrix(src_nodes, target_nodes):
         connection for connection in connect_values if nest.GetStatus([connection], "target")[0] in target_nodes
     ]
 
-    adjacency_mat = np.zeros((len(src_nodes), len(target_nodes)), dtype='uint8')
+    adjacency_mat = np.zeros((len(src_nodes), len(target_nodes)))
     adjacency_mat = set_values_in_adjacency_matrix(connect_values, adjacency_mat, min(src_nodes), min(target_nodes))
     return adjacency_mat
 

--- a/modules/networkConstruction.py
+++ b/modules/networkConstruction.py
@@ -1261,7 +1261,7 @@ def create_connections_rf(
     num_tuning_discr = max(neuron_to_tuning_map.values()) + 1
     tuning_discr_step = 256 / float(num_tuning_discr)
     min_id_target = min(target_node_ids)
-    adj_mat = np.zeros((image.size, len(target_node_ids)), dtype='uint8')
+    adj_mat = np.zeros((image.size, len(target_node_ids)))
 
     if connect_dict is None:
         connect_dict = {


### PR DESCRIPTION
Since functions return weigth matrices instead of adjacency matrices
it's crucial to change datatype such that continuous weights are
added to the matrix and not cut off by interger cast